### PR TITLE
Remove redundant functions.sh sourcing (fixes #4)

### DIFF
--- a/plugins/dir
+++ b/plugins/dir
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-source ${MPATH}/lib/functions.sh
-
-
 # TODO:
 # * include a function to delete older directories by days or mins
 # * include a function to delete newest directories by days or mins


### PR DESCRIPTION
$MPATH is not defined in the scope of plugin files, and functions.sh is already sourced in the main m script