### PR TITLE
Fix launching 'm' from a symlink.

### DIFF
--- a/m
+++ b/m
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-pushd `dirname $0` > /dev/null
+if [ -L $0 ]; then
+    pushd `readlink $0 | xargs dirname` > /dev/null
+else
+    pushd `dirname $0` > /dev/null
+fi
 MPATH=`pwd -P`
 popd > /dev/null
 


### PR DESCRIPTION
This follows symlinks on $0 using `readlink` to establish a more
credible path for ${MPATH}.  It's now no longer required to have
/usr/local/m-cli on your path.  You could, for example, throw a
link to /usr/local/m-cli/m into /usr/local/bin.