### PR TITLE
Fixes #13 - Don't error when trash is empty

### DIFF
--- a/plugins/trash
+++ b/plugins/trash
@@ -13,8 +13,10 @@ __EOF__
 
 clean_trash(){
     [ ! -e "$HOME/.Trash"  ] && echo "Trash not found" && exit 1
-    sudo chflags -R nouchg $HOME/.Trash/*
-    sudo rm -rf $HOME/.Trash/*
+    if [[ "$(ls $HOME/.Trash/)" !=  "" ]]; then
+        sudo chflags -R nouchg $HOME/.Trash/* ;
+        sudo rm -rf $HOME/.Trash/*;
+    fi
 
 }
 


### PR DESCRIPTION
Added if to check if files exist before trying to delete.
