### PR TITLE
Does not required sudo.

### DIFF
--- a/plugins/wifi
+++ b/plugins/wifi
@@ -24,7 +24,7 @@ wifi_status(){
 }
 
 wifi_scan(){
-    sudo /System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -s
+    /System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -s
 }
 
 wifi_history(){


### PR DESCRIPTION
We can call the `/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -s` directly without `sudo`