### PR TITLE
Issue 9: Use SACLockScreenImmediate() to lock the screen.

### DIFF
--- a/plugins/lock
+++ b/plugins/lock
@@ -1,25 +1,34 @@
-#!/bin/sh
+#!/usr/bin/python
 
-help(){
-    cat<<__EOF__
-    usage:  m lock [ help ]
+from ctypes import CDLL
+import sys
+
+def help():
+    print """    usage: m lock [ help ]
 
     Examples:
-      m lock      # lock session
-__EOF__
-}
+      m lock     # lock session"""
+    sys.exit()
 
-lock(){
-    /System/Library/CoreServices/Menu\ Extras/User.menu/Contents/Resources/CGSession -suspend
-}
+def lock():
+    path = '/System/Library/PrivateFrameworks/login.framework/Versions/Current/login'
+    try:
+        login = CDLL(path)
+        login.SACLockScreenImmediate()
+    except OSError:
+        print "Couldn't load framework: ", path
+    except AttributeError:
+        print "Function is not available."
 
-case $1 in
-    help)
-        help
-        ;;
-    *)
-        lock
-        ;;
-esac
+def main(args):
+    for arg in args:
+        if arg == 'help':
+            help()
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+    lock()
+
+if __name__ == "__main__":
+    main(sys.argv[1:])
+
+
+


### PR DESCRIPTION
This will directly lock the screen without presenting the user-switching login screen.