### PR TITLE
Handle wifi network names with spaces

### DIFF
--- a/completion/zsh/_m
+++ b/completion/zsh/_m
@@ -561,5 +561,4 @@ function _m {
     esac
 }
 
-_m $@
-
+_m "$@"

--- a/plugins/wifi
+++ b/plugins/wifi
@@ -45,7 +45,9 @@ wifi_on(){
 
 connect_network(){
     [ -z "$1" -o -z "$2" ] && help
-    networksetup -setairportnetwork ${_W_DEVICE} $1 $@
+    NETWORK="$1"
+    shift
+    networksetup -setairportnetwork "${_W_DEVICE}" "${NETWORK}" "$@"
 }
 
 case $1 in
@@ -66,7 +68,7 @@ case $1 in
         ;;
     connect)
         shift
-        connect_network $@
+        connect_network "$@"
         ;;
     history)
         shift
@@ -74,7 +76,7 @@ case $1 in
         ;;
     showpassword)
         shift
-        wifi_showpassword $@
+        wifi_showpassword "$@"
         ;;
     *)
         help


### PR DESCRIPTION
I encountered a bug trying to do `m wifi connect "Cannon mine coffee" the-wifi-password`. Shell word splitting at the `m` and `wifi` scripts was causing the parameter to be passed down as just `Cannon`.

I fixed the specific instances affecting my use case, but I believe unquoted variables are a pervasive issue in this code base that will make it misbehave with values containing spaces. I ran it through [shellcheck](https://github.com/koalaman/shellcheck) and there are many instances of rule "SC2086: Double quote to prevent globbing and word splitting." firing.

If you accept this pull request and agree with the analysis, I'd be willing to submit a further PR to fully resolve other instances of this issue throughout the code base. I'd need to lean on the maintainers to help with testing though.