### PR TITLE
Made m wifi showpassword nicer

### DIFF
--- a/plugins/wifi
+++ b/plugins/wifi
@@ -10,7 +10,7 @@ help(){
     Examples:
       m wifi status                  # wifi status
       m wifi scan                    # scan wifi
-      m wifi showpassword ESSID      # show wifi network password
+      m wifi showpassword [ESSID]    # show wifi network password (default: current)
       m wifi history                 # wifi connection history
       m wifi off                     # turn off your wifi
       m wifi on                      # turn on your wifi
@@ -31,8 +31,13 @@ wifi_history(){
 }
 
 wifi_showpassword(){
-    [ -z "$1" ] && help && exit 1
-    security find-generic-password -D "AirPort network password" -a $1 -gw
+    if [ -z "$1" ] 
+    then 
+        ssid="`/usr/local/bin/airport -I | awk '/ SSID/ {print substr($0, index($0, $2))}'`"
+    else
+        ssid=$1
+    fi
+    security find-generic-password -D "AirPort network password" -a "$ssid" -gw
 }
 
 wifi_off(){


### PR DESCRIPTION
It would be nicer to just call `m wifi showpassword` to get the CURRENT
password

```bash
$ m wifi showpassword <SSID>
******
$ m wifi showpassword
******
```