### PR TITLE
Use more native bash for `dns flush`

### DIFF
--- a/plugins/dns
+++ b/plugins/dns
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 help(){
     cat<<__EOF__
@@ -11,16 +11,23 @@ __EOF__
 
 
 flushdns(){
-    VERSION=$(sw_vers -productVersion)
+    product_version=$(sw_vers -productVersion)
+    semver=( ${product_version//./ } )
+    major="${semver[0]}"
+    minor="${semver[1]}"
+    patch="${semver[2]}"
     echo "Flushing dns..."
-    if echo $VERSION | grep -E '^10\.10(\.[0-3])?$' >/dev/null 2>&1; then
+    if [[ ${patch} =~ [0-3] && ${minor} -eq 10 ]]; then
+        # 10.10.0 - 10.10.3
         sudo discoveryutil mdnsflushcache
-    elif echo $VERSION | grep -E '^10\.6(\.[0-8])?$' >/dev/null 2>&1; then
+    elif [[ ${minor} -eq 6 ]]; then
+        # 10.6.x
         sudo dscacheutil -flushcache
     else
         sudo killall -HUP mDNSResponder
     fi
 }
+
 
 
 case $1 in

--- a/plugins/dns
+++ b/plugins/dns
@@ -17,17 +17,16 @@ flushdns(){
     minor="${semver[1]}"
     patch="${semver[2]}"
     echo "Flushing dns..."
-    if [[ ${patch} =~ [0-3] && ${minor} -eq 10 ]]; then
+    if [[ ${patch} =~ [0-3] && ${minor} -eq 10 && ${major} -eq 10 ]]; then
         # 10.10.0 - 10.10.3
         sudo discoveryutil mdnsflushcache
-    elif [[ ${minor} -eq 6 ]]; then
+    elif [[ ${minor} -eq 6 && ${major} -eq 10 ]]; then
         # 10.6.x
         sudo dscacheutil -flushcache
-    else
+    elif [[ ${major} -eq 10 ]]; then
         sudo killall -HUP mDNSResponder
     fi
 }
-
 
 
 case $1 in


### PR DESCRIPTION
This update allows for the `dns flush` command to use more native bash for the if statements, resulting in cleaner, more efficient code.