### PR TITLE
Improve finder subcommands

### DIFF
--- a/completion/bash/m
+++ b/completion/bash/m
@@ -32,7 +32,7 @@ _m_sub () {
             )
             ;;
 		finder)
-			subcommands=(showhiddenfiles showextensions desktop help)
+			subcommands=(showhiddenfiles showextensions showdesktop help)
 			;;
 		firewall)
 			subcommands=(status enable disable add help)

--- a/completion/zsh/_m
+++ b/completion/zsh/_m
@@ -402,10 +402,10 @@ function _m_cmd {
                 "NO:don't show all file extensions"
             _m_yesno \
                 $sub \
-                "desktop" \
-                "show desktop status" \
-                "enable:enables desktop" \
-                "disable:disables desktop"
+                "showdesktop" \
+                "manage desktop status" \
+                "YES:enable desktop" \
+                "NO:disable desktop"
             _m_yesno \
             ;;
         firewall)

--- a/completion/zsh/_m
+++ b/completion/zsh/_m
@@ -391,13 +391,13 @@ function _m_cmd {
             _m_yesno \
                 $sub \
                 "showhiddenfiles" \
-                "get or set hidden property" \
+                "manage hidden file visibility" \
                 "YES:show hidden files" \
                 "NO:don't show hidden files"
             _m_yesno \
                 $sub \
                 "showextensions" \
-                "get or set showextension property" \
+                "manage file extension visibility" \
                 "YES:show all file extensions" \
                 "NO:don't show all file extensions"
             _m_yesno \
@@ -406,7 +406,6 @@ function _m_cmd {
                 "manage desktop status" \
                 "YES:enable desktop" \
                 "NO:disable desktop"
-            _m_yesno \
             ;;
         firewall)
             _m_firewall

--- a/plugins/finder
+++ b/plugins/finder
@@ -4,7 +4,7 @@
 
 help(){
     cat<<__EOF__
-    usage: m finder [ showhiddenfiles | showfileextensions | desktop | help ]
+    usage: m finder [ showhiddenfiles | showfileextensions | showdesktop | help ]
 
     Examples:
       m finder showhiddenfiles           # get the current status
@@ -13,9 +13,9 @@ help(){
       m finder showextensions            # get the current status
       m finder showextensions YES        # show all file extensions
       m finder showextensions NO         # don't show all file extensions
-      m finder desktop                   # get the current desktop status
-      m finder desktop enable            # enable the desktop
-      m finder desktop disable           # disable the desktop
+      m finder showdesktop               # get the current desktop status
+      m finder showdesktop YES           # enable the desktop
+      m finder showdesktop NO            # disable the desktop
 __EOF__
 }
 
@@ -57,12 +57,12 @@ file_extensions(){
 
 desktop(){
     case $1 in
-        enable)
-            echo "Enables Desktop"
+        [yY][eE][sS])
+            echo "Enable desktop: YES"
             defaults write com.apple.finder CreateDesktop -bool TRUE
             ;;
-        disable)
-            echo "Disables Desktop"
+        [nN][oO])
+            echo "Enable desktop: NO"
             defaults write com.apple.finder CreateDesktop -bool FALSE
             ;;
         *)
@@ -90,7 +90,7 @@ case $1 in
         shift
         file_extensions $@
         ;;
-    desktop)
+    showdesktop)
         shift
         desktop $@
         ;;

--- a/plugins/finder
+++ b/plugins/finder
@@ -30,7 +30,17 @@ hidden_files(){
             defaults write com.apple.finder AppleShowAllFiles NO
             ;;
         *)
-            echo "Show Hidden files: $(defaults read com.apple.finder AppleShowAllFiles)"
+            HIDDEN_FILE_STATUS=$(defaults read com.apple.finder AppleShowAllFiles 2>/dev/null | tr '[:upper:]' '[:lower:]')
+            if \
+              [ -z "$HIDDEN_FILE_STATUS" ] || \
+              [ "$HIDDEN_FILE_STATUS" = "false" ] || \
+              [ "$HIDDEN_FILE_STATUS" = "no" ] || \
+              [ "$HIDDEN_FILE_STATUS" -eq 0 ] ; then
+                HIDDEN_FILE_STATUS_WORD="NO"
+            else
+                HIDDEN_FILE_STATUS_WORD="YES"
+            fi
+            echo "Show hidden files: $HIDDEN_FILE_STATUS_WORD"
             exit 1
             ;;
     esac
@@ -48,7 +58,17 @@ file_extensions(){
             defaults write NSGlobalDomain AppleShowAllExtensions NO
             ;;
         *)
-            echo "Show All File Extensions: $(defaults read NSGlobalDomain AppleShowAllExtensions)"
+            EXTENSION_STATUS=$(defaults read NSGlobalDomain AppleShowAllExtensions 2>/dev/null | tr '[:upper:]' '[:lower:]')
+            if \
+              [ -z "$EXTENSION_STATUS" ] || \
+              [ "$EXTENSION_STATUS" = "false" ] || \
+              [ "$EXTENSION_STATUS" = "no" ] || \
+              [ "$EXTENSION_STATUS" -eq 0 ] ; then
+                EXTENSION_STATUS_WORD="NO"
+            else
+                EXTENSION_STATUS_WORD="YES"
+            fi
+            echo "Show file extensions: $EXTENSION_STATUS_WORD"
             exit 1
             ;;
     esac
@@ -66,13 +86,17 @@ desktop(){
             defaults write com.apple.finder CreateDesktop -bool FALSE
             ;;
         *)
-            DESKTOP_STATUS_NUM=$(defaults read com.apple.finder CreateDesktop 2>/dev/null)
-            if [ "$DESKTOP_STATUS_NUM" -eq 0 ] ; then
-              DESKTOP_STATUS="disabled"
+            DESKTOP_STATUS=$(defaults read com.apple.finder CreateDesktop 2>/dev/null | tr '[:upper:]' '[:lower:]')
+            if \
+              [ -z "$DESKTOP_STATUS" ] || \
+              [ "$DESKTOP_STATUS" = "true" ] || \
+              [ "$DESKTOP_STATUS" = "yes" ] || \
+              [ "$DESKTOP_STATUS" -eq 1 ] ; then
+                DESKTOP_STATUS_WORD="enabled"
             else
-              DESKTOP_STATUS="enabled"
+                DESKTOP_STATUS_WORD="enabled"
             fi
-            echo "Desktop is: $DESKTOP_STATUS"
+            echo "Desktop: $DESKTOP_STATUS_WORD"
             ;;
     esac
     killall Finder

--- a/plugins/finder
+++ b/plugins/finder
@@ -22,12 +22,12 @@ __EOF__
 hidden_files(){
     case $1 in
         [yY][eE][sS])
-            echo "Show Hidden files: YES"
-            defaults write com.apple.finder AppleShowAllFiles YES
+            echo "Show hidden files: YES"
+            defaults write com.apple.finder AppleShowAllFiles -bool true
             ;;
         [nN][oO])
-            echo "Show Hidden files: NO"
-            defaults write com.apple.finder AppleShowAllFiles NO
+            echo "Show hidden files: NO"
+            defaults write com.apple.finder AppleShowAllFiles -bool false
             ;;
         *)
             HIDDEN_FILE_STATUS=$(defaults read com.apple.finder AppleShowAllFiles 2>/dev/null | tr '[:upper:]' '[:lower:]')
@@ -51,11 +51,11 @@ file_extensions(){
     case $1 in
         [yY][eE][sS])
             echo "Show file extensions: YES"
-            defaults write NSGlobalDomain AppleShowAllExtensions YES
+            defaults write NSGlobalDomain AppleShowAllExtensions -bool true
             ;;
         [nN][oO])
             echo "Show file extensions: NO"
-            defaults write NSGlobalDomain AppleShowAllExtensions NO
+            defaults write NSGlobalDomain AppleShowAllExtensions -bool false
             ;;
         *)
             EXTENSION_STATUS=$(defaults read NSGlobalDomain AppleShowAllExtensions 2>/dev/null | tr '[:upper:]' '[:lower:]')
@@ -79,11 +79,11 @@ desktop(){
     case $1 in
         [yY][eE][sS])
             echo "Enable desktop: YES"
-            defaults write com.apple.finder CreateDesktop -bool TRUE
+            defaults write com.apple.finder CreateDesktop -bool true
             ;;
         [nN][oO])
             echo "Enable desktop: NO"
-            defaults write com.apple.finder CreateDesktop -bool FALSE
+            defaults write com.apple.finder CreateDesktop -bool false
             ;;
         *)
             DESKTOP_STATUS=$(defaults read com.apple.finder CreateDesktop 2>/dev/null | tr '[:upper:]' '[:lower:]')

--- a/plugins/finder
+++ b/plugins/finder
@@ -9,7 +9,7 @@ help(){
     Examples:
       m finder showhiddenfiles           # get the current status
       m finder showhiddenfiles YES       # show hidden files
-      m finder showhiddenfiles NO        # no show hidden files
+      m finder showhiddenfiles NO        # don't show hidden files
       m finder showextensions            # get the current status
       m finder showextensions YES        # show all file extensions
       m finder showextensions NO         # don't show all file extensions
@@ -40,11 +40,11 @@ hidden_files(){
 file_extensions(){
     case $1 in
         [yY][eE][sS])
-            echo "Show Hidden files: YES"
+            echo "Show file extensions: YES"
             defaults write NSGlobalDomain AppleShowAllExtensions YES
             ;;
         [nN][oO])
-            echo "Show Hidden files: NO"
+            echo "Show file extensions: NO"
             defaults write NSGlobalDomain AppleShowAllExtensions NO
             ;;
         *)

--- a/plugins/finder
+++ b/plugins/finder
@@ -108,15 +108,15 @@ case $1 in
         ;;
     showhiddenfiles)
         shift
-        hidden_files $@
+        hidden_files "$@"
         ;;
     showextensions)
         shift
-        file_extensions $@
+        file_extensions "$@"
         ;;
     showdesktop)
         shift
-        desktop $@
+        desktop "$@"
         ;;
     *)
         help


### PR DESCRIPTION
This pull request:

0. Changes `m finder desktop` to `m finder showdesktop`
0. Makes `m finder showdesktop` take `yes` and `no`, case-insensitively, to match the other `m finder` commands
0. Handles issues with missing defaults values or varying data types
0. Makes `m finder` use the boolean data type when writing defaults values
0. Fixes some shell completion issues
0. Makes minor shell scripting improvements

Fixes #68.
Fixes #70.