### PR TITLE
FIXED modeline string (wasn't working)

### DIFF
--- a/completion/bash/m
+++ b/completion/bash/m
@@ -276,5 +276,4 @@ _m () {
 #complete -F _m m
 complete -o bashdefault -o default -F _m m
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
-
+# vim: ts=4 sw=4 softtabstop=4 expandtab ft=sh

--- a/install.sh
+++ b/install.sh
@@ -54,5 +54,5 @@ else
     exit 1
 fi
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab
 

--- a/m
+++ b/m
@@ -71,5 +71,5 @@ ${MPATH}/plugins/${COMMAND} "$@"
 
 
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab
 

--- a/plugins/battery
+++ b/plugins/battery
@@ -25,4 +25,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/bluetooth
+++ b/plugins/bluetooth
@@ -32,4 +32,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/dir
+++ b/plugins/dir
@@ -106,4 +106,4 @@ case "$1" in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/disk
+++ b/plugins/disk
@@ -152,4 +152,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/dns
+++ b/plugins/dns
@@ -35,4 +35,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/dock
+++ b/plugins/dock
@@ -151,4 +151,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/finder
+++ b/plugins/finder
@@ -133,4 +133,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/firewall
+++ b/plugins/firewall
@@ -36,4 +36,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/gatekeeper
+++ b/plugins/gatekeeper
@@ -69,4 +69,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/group
+++ b/plugins/group
@@ -68,4 +68,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/hostname
+++ b/plugins/hostname
@@ -45,4 +45,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/info
+++ b/plugins/info
@@ -19,4 +19,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/lock
+++ b/plugins/lock
@@ -32,4 +32,4 @@ if __name__ == "__main__":
     main(sys.argv[1:])
 
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/network
+++ b/plugins/network
@@ -70,4 +70,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/nosleep
+++ b/plugins/nosleep
@@ -40,4 +40,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/ntp
+++ b/plugins/ntp
@@ -36,4 +36,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/restart
+++ b/plugins/restart
@@ -32,4 +32,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/safeboot
+++ b/plugins/safeboot
@@ -33,4 +33,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/screensaver
+++ b/plugins/screensaver
@@ -49,4 +49,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/service
+++ b/plugins/service
@@ -115,4 +115,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/shutdown
+++ b/plugins/shutdown
@@ -32,4 +32,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/sleep
+++ b/plugins/sleep
@@ -19,4 +19,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/timezone
+++ b/plugins/timezone
@@ -29,4 +29,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/trash
+++ b/plugins/trash
@@ -34,4 +34,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/user
+++ b/plugins/user
@@ -126,4 +126,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/volume
+++ b/plugins/volume
@@ -61,4 +61,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/vpn
+++ b/plugins/vpn
@@ -74,4 +74,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/wallpaper
+++ b/plugins/wallpaper
@@ -38,4 +38,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab

--- a/plugins/wifi
+++ b/plugins/wifi
@@ -88,4 +88,4 @@ case $1 in
         ;;
 esac
 
-# vim: set ts=4 sw=4 softtabstop=4 expandtab
+# vim: ts=4 sw=4 softtabstop=4 expandtab


### PR DESCRIPTION
**`sed -e 's/^# vim: set /# vim: /'`**

modeline has 2 different syntaxes:

1.  # vim: **set**  ts=4 sw=4  **:**
2. # vim: ts=4 sw=4

the first one being adapt to comments having characters at the end of the line (`/* ... */`)

Syntax used was none of the above, so it was not working