### PR TITLE
Add relative volume commands to volume

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -438,10 +438,14 @@ usage:  m [OPTIONS] COMMAND [help]
 
 #### Volume:
 ```
-    usage:  m volume [ level(0-100) | mute | unmute | ismute ]
+    usage:  m volume [ level(0-100) | change(-n|+n) | up | down | mute | unmute | ismute ]
 
     Examples:
       m volume 70     # set the volume to 70 %
+      m volume +5     # increase the volume by 5 (up to 100)
+      m volume -10    # decrease the volume by 5 (down to 0)
+      m volume up     # increase the volume by 6.25
+      m volume down   # decrease the volume by 6.25
       m volume        # get the volume level
       m volume mute   # set mute
       m volume unmute # unset mute

--- a/completion/bash/m
+++ b/completion/bash/m
@@ -100,7 +100,7 @@ _m_sub () {
             subcommands=(ls install help)
             ;;
         volume)
-            subcommands=(mute unmute ismute help)
+            subcommands=(up down mute unmute ismute help)
             ;;
         vpn)
             subcommands=(list status stop start help)

--- a/completion/fish/m.fish
+++ b/completion/fish/m.fish
@@ -201,6 +201,8 @@ complete -f -c m -n '__fish_m_using_command update' -a "install" -d 'install upd
 complete -f -c m -n '__fish_m_using_command update' -a "help" -d 'Show help'
 
 complete -f -c m -n '__fish_m_needs_command' -a volume -d "Manage the sound's volume"
+complete -f -c m -n '__fish_m_using_command volume' -a "up" -d 'increase the volume'
+complete -f -c m -n '__fish_m_using_command volume' -a "down" -d 'decrease the volume'
 complete -f -c m -n '__fish_m_using_command volume' -a "mute" -d 'set mute'
 complete -f -c m -n '__fish_m_using_command volume' -a "unmute" -d 'unset mute'
 complete -f -c m -n '__fish_m_using_command volume' -a "ismute" -d 'check the volume status'

--- a/completion/zsh/_m
+++ b/completion/zsh/_m
@@ -530,6 +530,8 @@ function _m_cmd {
         volume)
             _m_solo \
                 $sub \
+                "up:increase the volume" \
+                "down:decrease the volume" \
                 "mute:set mute" \
                 "unmute:unset mute" \
                 "ismute:check the volume status" \

--- a/plugins/volume
+++ b/plugins/volume
@@ -3,10 +3,14 @@
 
 help(){
     cat<<__EOF__
-    usage:  m volume [ level(0-100) | mute | unmute | ismute ]
+    usage:  m volume [ level(0-100) | change(-n|+n) | up | down | mute | unmute | ismute ]
 
     Examples:
       m volume 70     # set the volume to 70 %
+      m volume +5     # increase the volume by 5 (up to 100)
+      m volume -10    # decrease the volume by 5 (down to 0)
+      m volume up     # increase the volume by 6.25
+      m volume down   # decrease the volume by 6.25
       m volume        # get the volume level
       m volume mute   # set mute
       m volume unmute # unset mute
@@ -35,6 +39,11 @@ set_vol(){
     echo "Vol: $1"
 }
 
+adj_vol(){
+    osascript -e "set volume output volume (get output volume of (get volume settings) $1)"
+    get_vol
+}
+
 get_vol(){
     VALUE=$(osascript -e "output volume of (get volume settings)")
     echo "Vol: $VALUE"
@@ -43,6 +52,15 @@ get_vol(){
 case $1 in
     [0-9]*)
         set_vol $1
+        ;;
+    +[0-9]*|-[0-9]*)
+        adj_vol $1
+        ;;
+    up)
+        adj_vol +6.25
+        ;;
+    down)
+        adj_vol -6.25
         ;;
     mute)
         mute


### PR DESCRIPTION
I wanted a way to increase/decrease volume without first querying it. This adds things like `m volume +5`, `m volume down`, etc. Luckily applescript (or something) is smart enough to cap it at 0 and 100!
- Prepending a number with `+` will increase the current volume by that
  much (up to 100)
- Prepending a number with `-` will decease the current volume by that
  much (down to 0)
- `up` will increase by 100/6 (like the keyboard)
- `down` will decrease by 100/6 (like the keyboard)
