### PR TITLE
Remove extra space in zsh completion

### DIFF
--- a/completion/zsh/_m
+++ b/completion/zsh/_m
@@ -191,7 +191,7 @@ function _m_dock {
             "position:change Dock's position"
             "addblankspace:add a blank space(separator) to the dock"
             "addrecentitems:add a stack containg your recent items to the Dock"
-            "prune: removes all apps from dock"
+            "prune:removes all apps from dock"
             help
         )
 


### PR DESCRIPTION
Just a formatting thing. Makes the comments line up when you run autocomplete