### PR TITLE
Set wallpaper only when needed - to avoid unnecessary 'killall Dock'

### DIFF
--- a/plugins/wallpaper
+++ b/plugins/wallpaper
@@ -19,7 +19,11 @@ set_wallpaper(){
             osascript -e "tell application \"Finder\" to set desktop picture to POSIX file \"${1}\""
             ;;
         sqlite3)
-            sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "update data set value = '${1}'" && killall Dock
+            DB_PATH="$HOME/Library/Application Support/Dock/desktoppicture.db"
+            current_path=$(sqlite3 -noheader -batch "$DB_PATH" 'select value from data limit 1')
+            if [[ "$current_path" != "$1" ]]; then
+                sqlite3 "$DB_PATH" "update data set value = '${1}'" && killall Dock
+            fi
             ;;
         *)
             echo "I can't set the wallpaper" && exit 1


### PR DESCRIPTION
To make `killall Dock` run only when it's needed, to avoid a flash caused by it.

**Use case**
I change my wallpaper using a script which runs periodically, and I'd like to avoid `killall Dock` whenever possible.