### PR TITLE
showpath option added to finder so people can see a folder's full pat…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -204,6 +204,9 @@ usage:  m [OPTIONS] COMMAND [help]
       m finder showdesktop YES           # enable the desktop
       m finder showdesktop NO            # disable the desktop
 
+      m finder showpath YES              # show the current opened folder path on the top bar of the Finder window
+      m finder showpath NO               # show the current opened folder name on the top bar of the Finder window
+
 ```
 
 #### Firewall:

--- a/Readme.md
+++ b/Readme.md
@@ -189,7 +189,7 @@ usage:  m [OPTIONS] COMMAND [help]
 
 #### Finder:
 ```
-    usage: m finder [ showhiddenfiles | showfileextensions | showdesktop | help  ]
+    usage: m finder [ showhiddenfiles | showfileextensions | showdesktop | showpath | help  ]
 
     Examples:
       m finder showhiddenfiles           # get the current status

--- a/plugins/finder
+++ b/plugins/finder
@@ -18,6 +18,9 @@ help(){
       m finder showdesktop               # get the current desktop status
       m finder showdesktop YES           # enable the desktop
       m finder showdesktop NO            # disable the desktop
+
+      m finder showpath YES              # show the current opened folder path on the top bar of the Finder window
+      m finder showpath NO               # show the current opened folder name on the top bar of the Finder window
 __EOF__
 }
 
@@ -112,6 +115,36 @@ desktop(){
     killall Finder
 }
 
+path(){
+    case $1 in
+        [yY][eE][sS])
+            echo "Show folder path: YES"
+            defaults write com.apple.finder _FXShowPosixPathInTitle -bool true
+            ;;
+        [nN][oO])
+            echo "Show folder path: NO"
+            defaults write com.apple.finder _FXShowPosixPathInTitle -bool false
+            ;;
+        *)
+            EXTENSION_STATUS=$(defaults read NSGlobalDomain _FXShowPosixPathInTitle 2>/dev/null)
+            case $EXTENSION_STATUS in
+                0|[nN][oO]|[fF][aA][lL][sS][eE])
+                    EXTENSION_STATUS="NO"
+                    ;;
+                1|[yY][eE][sS]|[tT][rU][eE])
+                    EXTENSION_STATUS="YES"
+                    ;;
+                *)
+                    echo "We can't read _FXShowPosixPathInTitle property" && exit 1
+                    ;;
+            esac
+            echo "Show folder path: $EXTENSION_STATUS"
+            exit 0
+            ;;
+    esac
+    killall Finder
+}
+
 case $1 in
     help)
         help
@@ -127,6 +160,10 @@ case $1 in
     showdesktop)
         shift
         desktop "$@"
+        ;;
+    showpath)
+        shift
+        path "$@"
         ;;
     *)
         help

--- a/plugins/finder
+++ b/plugins/finder
@@ -4,7 +4,7 @@
 
 help(){
     cat<<__EOF__
-    usage: m finder [ showhiddenfiles | showfileextensions | showdesktop | help ]
+    usage: m finder [ showhiddenfiles | showfileextensions | showdesktop | showpath | help ]
 
     Examples:
       m finder showhiddenfiles           # get the current status
@@ -126,7 +126,7 @@ path(){
             defaults write com.apple.finder _FXShowPosixPathInTitle -bool false
             ;;
         *)
-            EXTENSION_STATUS=$(defaults read NSGlobalDomain _FXShowPosixPathInTitle 2>/dev/null)
+            EXTENSION_STATUS=$(defaults read com.apple.finder _FXShowPosixPathInTitle 2>/dev/null)
             case $EXTENSION_STATUS in
                 0|[nN][oO]|[fF][aA][lL][sS][eE])
                     EXTENSION_STATUS="NO"


### PR DESCRIPTION
showpath option added to finder so people can see a folder's full path on the top bar of the opened Finder window instead of just seeing the folder's name:

m finder showpath YES:

![screen shot 2017-05-12 at 1 49 20 am](https://cloud.githubusercontent.com/assets/13811157/25982755/8e74280a-36b5-11e7-8ad9-4b44e7c55892.png)


m finder showpath NO:

![screen shot 2017-05-12 at 1 49 35 am](https://cloud.githubusercontent.com/assets/13811157/25982730/654e5fb8-36b5-11e7-9c71-85a0db94b2cf.png)
