### PR TITLE
Make screensaver launching version-agnostic

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,6 +53,7 @@ usage:  m [OPTIONS] COMMAND [help]
         dock
         finder
         firewall
+        flightmode
         gatekeeper
         hostname
         info

--- a/plugins/screensaver
+++ b/plugins/screensaver
@@ -62,7 +62,7 @@ case $1 in
         status
         ;;
     *)
-        open /System/Library/Frameworks/ScreenSaver.framework/Versions/A/Resources/ScreenSaverEngine.app
+        open /System/Library/Frameworks/ScreenSaver.framework/Resources/ScreenSaverEngine.app
         ;;
 esac
 


### PR DESCRIPTION
Current script specifies `Versions/A/Resources`. macOS supplies an alias to the current version’s resources folder, so using this alias is safer in case a new version is released.

(May fix #114, I cannot test on 10.13.). 