### PR TITLE
Add autohidedelay command to Dock

### DIFF
--- a/completion/bash/m
+++ b/completion/bash/m
@@ -29,9 +29,9 @@ _m_sub () {
             ;;
         dock)
             subcommands=(
-                showdelay autohide magnification
-                position addblankspace addrecentitems
-                prune help
+                showdelay autohide autohidedelay
+                magnification position addblankspace
+                addrecentitems prune help
             )
             ;;
         finder)

--- a/completion/fish/m.fish
+++ b/completion/fish/m.fish
@@ -80,6 +80,7 @@ complete -f -c m -n '__fish_m_using_command dns' -a "help" -d 'Show help'
 complete -f -c m -n '__fish_m_needs_command' -a dock -d 'Manage dock'
 complete -f -c m -n '__fish_m_using_command dock' -a "showdelay" -d 'changes how long the Dock takes to show up when auto-hide is enabled'
 complete -f -c m -n '__fish_m_using_command dock' -a "autohide" -d "enable or disable Dock's auto hide feature"
+complete -f -c m -n '__fish_m_using_command dock' -a "autohidedelay" -d "changes how long the Dock takes to detect you want it to show up"
 complete -f -c m -n '__fish_m_using_command dock' -a "magnification" -d "enable or disable magnification"
 complete -f -c m -n '__fish_m_using_command dock' -a "position" -d "change Dock's position"
 complete -f -c m -n '__fish_m_using_command dock' -a "addblankspace" -d "add a blank space(separator) to the dock"

--- a/completion/zsh/_m
+++ b/completion/zsh/_m
@@ -187,6 +187,7 @@ function _m_dock {
         args=(
             "showdelay:changes how long the Dock takes to show up when auto-hide is enabled"
             "autohide:enable or disable Dock's auto hide feature"
+            "autohidedelay:changes how long the Dock takes to detect you want it to show up"
             "magnification:enable or disable magnification"
             "position:change Dock's position"
             "addblankspace:add a blank space(separator) to the dock"

--- a/plugins/dock
+++ b/plugins/dock
@@ -8,6 +8,7 @@ help(){
       m dock showdelay x.x          # Changes how long the Dock takes to show up when auto-hide is enabled
       m dock autohide YES           # Enable Dock's auto hide feature
       m dock autohide NO            # Disable Dock's auto hide feature
+      m dock autohidedelay x.x      # Changes how long it takes to detect you want to show up the dock
       m dock magnification YES      # Turn magnification on
       m dock magnification NO       # Turn magnification off
       m dock position BOTTOM        # Change Dock's position to the bottom of the screen
@@ -55,6 +56,25 @@ auto_hide(){
     esac
     killall Dock
 }
+
+autohide_delay(){
+    case $1 in
+    [0-9][.][0-9])
+        echo "New Auto-Hide delay time: "$1
+        defaults write com.apple.dock autohide-delay -float $1
+      ;;
+    [0-9])
+      echo "New Auto-Hide delay time: "$1
+      defaults write com.apple.dock autohide-delay -int $1
+      ;;
+    *)
+      echo "Current Auto-Hide delay time: $(defaults read com.apple.dock autohide-delay 2>/dev/null)"
+      exit 0
+      ;;
+  esac
+  killall Dock
+}
+
 
 magnify(){
     case $1 in
@@ -125,6 +145,10 @@ case $1 in
     autohide)
         shift
         auto_hide $@
+        ;;
+    autohidedelay)
+        shift
+        autohide_delay $@
         ;;
     magnification)
         shift


### PR DESCRIPTION
This command controls the `autohide-delay` Dock property.

The auto-hide delay (AFAIK) controls the time the pointer needs to be on the edge of the screen for the Dock to show up, as opposed to `autohide-time-modifier` which controls the animation duration.