### PR TITLE
New subcommand 'audio'

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -98,6 +98,7 @@ In this example, running `m itunes play` will play the current selected track in
 **m-cli** currently supports the following commands:
 
 `help`</br>
+`audio`</br>
 `battery`</br>
 `bluetooth`</br>
 `dir`</br>

--- a/completion/bash/m
+++ b/completion/bash/m
@@ -6,6 +6,9 @@ _m_sub () {
     case "$prev" in
         help)
             ;;
+        audio)
+            subcommands=(reset help)
+            ;;
         airdrop)
             subcommands=(status on enable off disable help)
             ;;
@@ -232,7 +235,7 @@ _m_dock() {
 _m () {
     local cur
     local commands=(
-        help airdrop battery bluetooth dir disk dns dock finder firewall flightmode gatekeeper group hostname
+        help audio airdrop battery bluetooth dir disk dns dock finder firewall flightmode gatekeeper group hostname
         info itunes lock network nosleep notification ntp printer restart safeboot screensaver service
         shutdown sleep timezone touchbar trash user update volume vpn wallpaper wifi
     )

--- a/completion/fish/m.fish
+++ b/completion/fish/m.fish
@@ -36,6 +36,9 @@ end
 complete -f -c m -n '__fish_m_needs_command' -l update -d 'Update m-cli'
 complete -f -c m -n '__fish_m_needs_command' -l uninstall -d 'Uninstall m-cli'
 
+complete -f -c m -n '__fish_m_needs_command' -a 'audio' -d 'Manage audio service'
+complete -f -c m -n '__fish_m_needs_command audio' -a 'reset' -d 'resets coreaudiod'
+
 complete -f -c m -n '__fish_m_needs_command' -a airdrop -d 'Manage airdrop status'
 complete -f -c m -n '__fish_m_using_command airdrop' -a "on" -d 'turn on airdrop'
 complete -f -c m -n '__fish_m_using_command airdrop' -a "enable" -d 'turn on airdrop'

--- a/completion/zsh/_m
+++ b/completion/zsh/_m
@@ -1,4 +1,4 @@
-#compdef m
+ #compdef m
 
 function _m_dir {
     local -a opts args
@@ -384,6 +384,11 @@ function _m_cmd {
     case $sub in
         help)
             ;;
+        audio)
+            _m_solo \
+                $sub \
+                "reset: restarts coreaudiod" \
+                help
         airdrop)
             _m_solo \
                 $sub \

--- a/plugins/audio
+++ b/plugins/audio
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+help(){
+    cat<<__EOF__
+    
+    usage: m audio [ reset | help ]
+
+    Examples:
+      m audio reset       # restarts coreaudiod
+__EOF__
+}
+
+reset(){
+    if [ "${1}" == "--hard" ]; then
+        sudo launchctl stop com.apple.audio.coreaudiod
+        sudo launchctl start com.apple.audio.coreaudiod
+    else
+        sudo killall coreaudiod
+    fi
+}
+
+case $1 in
+    help)
+        help
+        ;;
+    reset)
+        shift
+        reset "${@}"
+        ;;
+    *)
+        help
+        ;;
+esac


### PR DESCRIPTION
Sometimes mac's audio gets choppy and the only thing that
can fix it is a reset of the coreaudiod service.