### PR TITLE
added blockall argument to firewall plugin (to set firewall to state 2)

### DIFF
--- a/completion/fish/m.fish
+++ b/completion/fish/m.fish
@@ -120,6 +120,7 @@ complete -f -c m -n '__fish_m_using_command firewall' -a "enable" -d 'Enable fir
 complete -f -c m -n '__fish_m_using_command firewall' -a "disable" -d 'Disable firewall'
 complete -f -c m -n '__fish_m_using_command firewall' -a "add" -d 'Add app to firewall'
 complete -f -c m -n '__fish_m_using_command firewall' -a "remove" -d 'Remove app to firewall'
+complete -f -c m -n '__fish_m_using_command firewall' -a "blockall" -d 'Block all incoming connections'
 complete -f -c m -n '__fish_m_using_command firewall' -a "help" -d 'Show help'
 
 complete -f -c m -n '__fish_m_needs_command' -a flightmode -d 'Manage flightmode'

--- a/completion/zsh/_m
+++ b/completion/zsh/_m
@@ -233,6 +233,7 @@ function _m_firewall {
                 "disable:Disable firewall"
                 "add:Add app to firewall"
                 "remove:Remove app to firewall"
+                "blockall:Block all incoming connections"
                 help
             )
             ;;

--- a/plugins/firewall
+++ b/plugins/firewall
@@ -2,7 +2,7 @@
 
 help(){
     cat<<__EOF__
-    usage: m firewall [ status | enable | disable | list | add | remove | help ]
+    usage: m firewall [ status | enable | disable | list | add | remove | blockall | help ]
 
     Examples:
       m firewall status                # Show status
@@ -11,6 +11,7 @@ help(){
       m firewall list                  # List applications handled by firewall
       m firewall add /path/to/file     # Add app to firewall
       m firewall remove /path/to/file  # Remove app from firewall
+      m firewall blockall [ on | off ] # Block all connections (State 2)
 
 __EOF__
 }
@@ -22,7 +23,7 @@ case $1 in
         help
         ;;
     status)
-        sudo /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate
+        /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate
         ;;
     enable)
         sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on
@@ -31,7 +32,7 @@ case $1 in
         sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
         ;;
     list)
-        sudo /usr/libexec/ApplicationFirewall/socketfilterfw --list
+        /usr/libexec/ApplicationFirewall/socketfilterfw --list
         ;;
     add)
         [ -z "$2" ] && help && exit 1
@@ -41,6 +42,11 @@ case $1 in
         [ -z "$2" ] && help && exit 1
         sudo /usr/libexec/ApplicationFirewall/socketfilterfw --remove $2
         ;;
+    blockall)
+	[ "$2" != "on" ] && [ "$2" != "off" ] || [ -z "$2" ] && help && exit 1
+        sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setblockall $2
+        ;;
+	
     *)
         help
         ;;


### PR DESCRIPTION
Should be self explanatory but please let me know if you have any questions or feedback.

Did some testing and it all works as expected. 

One thing of interest is if you disable the firewall and then run `m firewall blockall on` it will turn the firewall on for you:

```bash
$ ./m firewall disable
Firewall is disabled. (State = 0)

$ ./m firewall blockall on
Firewall is set to block all non-essential incoming connections

$ ./m firewall status
Firewall is enabled. (State = 2)
```


Also, one other thing not related to firewall state 2 is that I removed `sudo` from the `m firewall status` command because I noticed you don't need to be root to check the firewall's state.