### PR TITLE
Add powermode plugin to handle the powermode on newer laptop macs

### DIFF
--- a/completion/bash/m
+++ b/completion/bash/m
@@ -88,6 +88,13 @@ _m_sub () {
         ntp)
             subcommands=(status enable disable set help)
             ;;
+        powermode)
+            subcommands=(
+                battery ac
+                auto low high
+                help
+            )
+            ;;
         printer)
             subcommands=(settings name queue drivers web help)
             ;;
@@ -235,11 +242,24 @@ _m_dock() {
     COMPREPLY=( $( compgen -W "${choices[*]}" -- $cur  )  )
 }
 
+_m_powermode() {
+    local prev="$1"
+    local sub="$2"
+    local choices=()
+
+    case "$sub" in
+        ac|battery)
+            [[ $COMP_CWORD == 3 ]] && choices=("", auto, low, high)
+            ;;
+    esac
+    COMPREPLY=( $( compgen -W "${choices[*]}" -- $cur  )  )
+}
+
 _m () {
     local cur
     local commands=(
         help audio airdrop battery bluetooth dir disk dns dock finder firewall flightmode gatekeeper group hostname
-        info itunes lock network nosleep notification ntp printer restart safeboot screensaver service
+        info itunes lock network nosleep notification ntp powermode printer restart safeboot screensaver service
         shutdown sleep timezone touchbar trash user update volume vpn wallpaper wifi
     )
 
@@ -298,6 +318,9 @@ _m () {
                     local _tmp=(*)
                     [[ $COMP_CWORD == 3 ]] \
                         && COMPREPLY=($(compgen -W "${_tmp[*]}" -- $cur))
+                    ;;
+                powermode)
+                    _m_powermode "$prev" "$sub"
                     ;;
                 screensaver)
                     [[ $sub == "askforpassword" && $COMP_CWORD == 3 ]] \

--- a/completion/fish/m.fish
+++ b/completion/fish/m.fish
@@ -201,6 +201,14 @@ complete -f -c m -n '__fish_m_using_command ntp' -a "disable" -d 'disable clock 
 complete -f -c m -n '__fish_m_using_command ntp' -a "set" -d 'set network time server'
 complete -f -c m -n '__fish_m_using_command ntp' -a "help" -d 'Show help'
 
+# XXX: Add completion for powermode subcommands and options
+complete -f -c m -n '__fish_m_needs_command' -a powermode -d 'Manage power mode'
+complete -f -c m -n '__fish_m_using_command powermode' -a "battery" -d "show/change power mode on battery"
+complete -f -c m -n '__fish_m_using_command powermode' -a "ac" -d "show/change power mode on ac"
+complete -f -c m -n '__fish_m_using_command powermode' -a "auto" -d "set global power mode to auto"
+complete -f -c m -n '__fish_m_using_command powermode' -a "low" -d "set global power mode to low"
+complete -f -c m -n '__fish_m_using_command powermode' -a "high" -d "set global power mode to high"
+
 complete -f -c m -n '__fish_m_needs_command' -a printer -d 'Display information about the printers'
 complete -f -c m -n '__fish_m_using_command printer' -a "settings" -d 'Display printer settings'
 complete -f -c m -n '__fish_m_using_command printer' -a "name" -d 'Display printer names on system'

--- a/completion/zsh/_m
+++ b/completion/zsh/_m
@@ -343,6 +343,33 @@ function _m_nosleep {
     _describe 'nosleep commands' opts -- args
 }
 
+function _m_powermode {
+    local -a opts args
+
+    if [[ $CURRENT == 3 ]]; then
+        args=(
+            "battery:show/change power mode on battery"
+            "ac:show/change power mode on ac"
+            "auto:set global power mode to auto"
+            "low:set global power mode to low"
+            "high:set global power mode to high"
+            help
+        )
+
+        #_describe 'manage power mode' opts -- args
+        #return
+    fi
+    local sub=${words[3]}
+
+    case $sub in
+        battery|ac)
+            [[ $CURRENT == 4 ]] && args=("" auto low high)
+            ;;
+    esac
+    _describe 'manage power mode' opts -- args
+    return
+}
+
 function _m_user {
     case $CURRENT in
         3)
@@ -405,6 +432,7 @@ function _m_cmd {
                 $sub \
                 "reset: restarts coreaudiod" \
                 help
+            ;;
         airdrop)
             _m_solo \
                 $sub \
@@ -555,6 +583,9 @@ function _m_cmd {
                 "disable:disable clock to use network time" \
                 "set:set network time server" \
                 help
+            ;;
+        powermode)
+            _m_powermode
             ;;
         printer)
             _m_solo \
@@ -707,6 +738,7 @@ function _m {
         "nosleep:prevent sleeping"
         "notification:manage the notification settings"
         "ntp:manage the network time service"
+        "powermode:manage power mode"
         "printer:display information about the printers"
         "restart:restart computer"
         "safeboot:manage safeboot"

--- a/plugins/powermode
+++ b/plugins/powermode
@@ -49,8 +49,7 @@ powermode() {
             sudo pmset -c powermode 2
             ;;
         "")
-            # TODO: figure out selecting this
-            get_powermode "$(pmset -g live | grep -i 'powermode' | awk '{print $2}')"
+            get_powermode "$(pmset -g custom | grep -A5000 -m1 -e 'AC Power' | grep -i 'powermode' -m1 | awk '{print $2}')"
             ;;
         *)
             help
@@ -69,8 +68,7 @@ powermode() {
             sudo pmset -b powermode 2
             ;;
         "")
-            # TODO: figure out selecting this
-            get_powermode "$(pmset -g live | grep -i 'powermode' | awk '{print $2}')"
+            get_powermode "$(pmset -g custom | grep -A5000 -m1 -e 'Battery Power' | grep -i 'powermode' -m1 | awk '{print $2}')"
             ;;
         *)
             help

--- a/plugins/powermode
+++ b/plugins/powermode
@@ -17,7 +17,6 @@ __EOF__
 }
 
 get_powermode() {
-    echo $1
     # convert to words
     case $1 in
     0)

--- a/plugins/powermode
+++ b/plugins/powermode
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+help() {
+    cat <<__EOF__
+    usage: m powermode [ battery | ac | auto | low | high | help ]
+
+    Examples:
+      m powermode                             # get the current power mode
+      m powermode battery                     # get the power mode for battery
+      m powermode ac                          # get the power mode for ac
+
+      m powermode auto | low | high           # set the current power mode
+      m powermode battery auto | low | high   # set the power mode for battery
+      m powermode ac auto | low | high        # set the power mode for ac
+
+__EOF__
+}
+
+get_powermode() {
+    echo $1
+    # convert to words
+    case $1 in
+    0)
+        powermode="auto"
+        ;;
+    1)
+        powermode="low"
+        ;;
+    2)
+        powermode="high"
+        ;;
+    *)
+        echo "We can't read the power mode" && exit 1
+        ;;
+    esac
+    echo "Power mode: $powermode"
+}
+
+powermode() {
+    case $1 in
+    ac)
+        case $2 in
+        auto)
+            sudo pmset -c powermode 0
+            ;;
+        low)
+            sudo pmset -c powermode 1
+            ;;
+        high)
+            sudo pmset -c powermode 2
+            ;;
+        "")
+            # TODO: figure out selecting this
+            get_powermode "$(pmset -g live | grep -i 'powermode' | awk '{print $2}')"
+            ;;
+        *)
+            help
+            ;;
+        esac
+        ;;
+    battery)
+        case $2 in
+        auto)
+            sudo pmset -b powermode 0
+            ;;
+        low)
+            sudo pmset -b powermode 1
+            ;;
+        high)
+            sudo pmset -b powermode 2
+            ;;
+        "")
+            # TODO: figure out selecting this
+            get_powermode "$(pmset -g live | grep -i 'powermode' | awk '{print $2}')"
+            ;;
+        *)
+            help
+            ;;
+        esac
+        ;;
+    "" | auto | low | high)
+        # no ac/battery specified
+        case $1 in
+        auto)
+            sudo pmset -a powermode 0
+            ;;
+        low)
+            sudo pmset -a powermode 1
+            ;;
+        high)
+            sudo pmset -a powermode 2
+            ;;
+        "")
+            get_powermode "$(pmset -g live | grep -i 'powermode' | awk '{print $2}')"
+            ;;
+        *)
+            help
+            ;;
+        esac
+        ;;
+    *)
+        help
+        ;;
+    esac
+}
+
+case $1 in
+help)
+    help
+    ;;
+# powermode)
+#     shift
+#     powermode "$@"
+#     ;;
+*)
+    # help
+    powermode "$@"
+    ;;
+esac


### PR DESCRIPTION
Newer macbooks have settings for different power modes, which controls things like fan curves and display refresh rate. This plugin allows users to change that with `m powermode`. 
