### PR TITLE
lock command use python3

### DIFF
--- a/plugins/lock
+++ b/plugins/lock
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from ctypes import CDLL


### PR DESCRIPTION
Hi, I have Sonoma 14.1 and by default there is no python executable, but rather a python3 one, located in /usr/bin/python3. Thus m lock does not work out of the box for me. Changing to pyhon3 solves my problem.