### PR TITLE
feat(restart): Add --auth flag for authenticated restart via fdesetup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ### All notable changes to this project will be documented in this file.
 ----
 
+## [2.0.8]
+
+### Updated
+- **`plugins/restart`**
+  - Added `--auth` flag: performs an authenticated restart via `fdesetup authrestart`, keeping FileVault unlock active across the reboot.
+
 ## [2.0.7]
 
 ### Added

--- a/plugins/restart
+++ b/plugins/restart
@@ -3,17 +3,19 @@
 
 help(){
     cat<<__EOF__
-Usage: m restart [--force | --help]
+Usage: m restart [--force | --auth | --help]
 
 Description: Restart the computer.
 
 Options:
   --help    Show this help message
   --force   Force restart without confirmation
+  --auth    Authenticated restart; keeps FileVault unlock active across reboot
 
 Examples:
   m restart          # Restart computer (needs confirmation)
   m restart --force  # Restart computer (without confirmation)
+  m restart --auth   # Authenticated restart (requires sudo; prompts for FileVault password)
 __EOF__
 }
 
@@ -25,6 +27,10 @@ force_restart(){
    osascript -e 'tell app "System Events" to restart'
 }
 
+auth_restart(){
+    sudo fdesetup authrestart
+}
+
 
 case $1 in
     --help)
@@ -32,6 +38,9 @@ case $1 in
         ;;
     -f|--force)
         force_restart
+        ;;
+    -a|--auth)
+        auth_restart
         ;;
     *)
         restart

--- a/tests/test_restart.sh
+++ b/tests/test_restart.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+PLUGIN="./plugins/restart"
+
+@test "restart --help exits 0" {
+  run $PLUGIN --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: m restart"* ]]
+}
+
+@test "restart --help documents --auth" {
+  run $PLUGIN --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--auth"* ]]
+}
+
+@test "restart --help documents --force" {
+  run $PLUGIN --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--force"* ]]
+}


### PR DESCRIPTION
`fdesetup authrestart` stores the user's password temporarily in RAM just long enough for the "Pre-boot" portion or a system restart.

**Problem:**
When Screen Sharing, rebooting requires me to go to the Host computer and re-enter my credentials.

**Solution:**
With the `--auth` flag, I can use `m reboot --auth` in a Screen Sharing session, the computer reboots, and Screen Sharing reconnects. I no longer have to go to the Host computer to type in my credentials.

**Tests:**
I added similar tests found in the repo for `restart`.

- `bats tests/test_restart.sh`
- Run `./m restart --help`
- Run `./m restart --auth`

The Mac will ask you for the sudo password, then your credentials, and reboot.

